### PR TITLE
Add support for std::filesystem types

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -4,10 +4,13 @@
 # std::runtime_error is not nothrow copy constructible (cert-err60-cpp)
 # Rule aliases are not useful (hicpp)
 # llvm-header-guard derives the macro name from the absolute path sometimes
+# sizeof(T*) is prohibited by bugprone-sizeof-expression
+# modernize-use-trailing-return-type is nonsense
 
 Checks: "\
   *,
   -fuchsia-*,\
+  -bugprone-sizeof-expression,\
   -cppcoreguidelines-avoid-c-arrays,\
   -cppcoreguidelines-avoid-magic-numbers,\
   -cppcoreguidelines-macro-usage,\
@@ -19,13 +22,16 @@ Checks: "\
   -hicpp-*,\
   -cert-err58-cpp,\
   -cert-err60-cpp,\
+  -readability-convert-member-functions-to-static,\
   -readability-magic-numbers,\
   -readability-named-parameter,\
   -readability-uppercase-literal-suffix,\
   -misc-non-private-member-variables-in-classes,\
   -modernize-avoid-c-arrays,\
   -modernize-use-auto,\
+  -modernize-use-nodiscard,\
   -modernize-return-braced-init-list,\
+  -modernize-use-trailing-return-type,\
   -llvm-header-guard,\
   -google-runtime-references"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
  - Support logging of std::optional
+ - Support logging of std::filesystem components
  - `binlog/char_ptr_is_string.hpp`: treat `char*` as string if included
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -334,6 +334,7 @@ if(Boost_FOUND)
   if(${CMAKE_CXX_STANDARD} GREATER_EQUAL 17)
     add_inttest(LoggingOptionals)
       include_boost(LoggingOptionals)
+    add_inttest(LoggingFilesystem)
   endif()
 
 else()

--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -188,6 +188,15 @@ see the Mserialize documentation on [Adapting custom types][mserialize-act] and
 [mserialize-act]: Mserialize.html#adapting-custom-types
 [mserialize-rec]: Mserialize.html#adapting-user-defined-recursive-types-for-visitation
 
+## Logging std::filesystem Types
+
+If C++17 is available, standard filesystem types can be made loggable:
+
+    [catchfile test/integration/LoggingFilesystem.cpp fs]
+
+The supported filesystem types are: `path`, `directory_entry`, `file_type`,
+`perms`, `space_info`, `file_status`.
+
 # Tools
 
 ## bread

--- a/include/binlog/adapt_stdfilesystem.hpp
+++ b/include/binlog/adapt_stdfilesystem.hpp
@@ -1,0 +1,82 @@
+#ifndef BINLOG_ADAPT_STDFILESYSTEM_HPP
+#define BINLOG_ADAPT_STDFILESYSTEM_HPP
+
+// Make std::filesystem components loggable by including this file
+
+#include <binlog/adapt_enum.hpp>
+#include <binlog/adapt_struct.hpp>
+
+#include <mserialize/serialize.hpp>
+#include <mserialize/tag.hpp>
+
+#include <filesystem>
+#include <string>
+
+// TODO Move SingleMemberSerializer
+
+BINLOG_ADAPT_ENUM(std::filesystem::file_type,
+  none, not_found, regular, directory, symlink, block, character, fifo, socket, unknown
+)
+
+BINLOG_ADAPT_ENUM(std::filesystem::perms,
+  none, owner_read, owner_write, owner_exec, owner_all, group_read,
+  group_write, group_exec, group_all, others_read, others_write, others_exec,
+  others_all, all, set_uid, set_gid, sticky_bit, mask
+)
+
+BINLOG_ADAPT_STRUCT(std::filesystem::space_info, capacity, free, available)
+
+BINLOG_ADAPT_STRUCT(std::filesystem::file_status, type, permissions)
+
+namespace mserialize {
+
+template <typename T, typename Member, Member member>
+struct SingleMemberSerializer
+{
+  template <typename OutputStream>
+  static void serialize(const T& t, OutputStream& ostream)
+  {
+    mserialize::serialize((t.*member)(), ostream);
+  }
+
+  static std::size_t serialized_size(const T& t)
+  {
+    return mserialize::serialized_size((t.*member)());
+  }
+};
+
+//
+// path
+//
+
+template <>
+struct CustomSerializer<std::filesystem::path>
+  :SingleMemberSerializer<
+    std::filesystem::path,
+    decltype(&std::filesystem::path::native),
+    &std::filesystem::path::native
+  >
+{};
+
+template <>
+struct CustomTag<std::filesystem::path> : detail::Tag<std::string>::type {};
+
+//
+// directory_entry
+//
+
+template <>
+struct CustomSerializer<std::filesystem::directory_entry>
+  :SingleMemberSerializer<
+    std::filesystem::directory_entry,
+    decltype(&std::filesystem::directory_entry::path),
+    &std::filesystem::directory_entry::path
+  >
+{};
+
+template <>
+struct CustomTag<std::filesystem::directory_entry> : detail::Tag<std::string>::type {};
+
+} // namespace mserialize
+
+#endif // BINLOG_ADAPT_STDFILESYSTEM_HPP

--- a/include/mserialize/StructDeserializer.hpp
+++ b/include/mserialize/StructDeserializer.hpp
@@ -44,6 +44,13 @@ auto deserializable_member(Field T::*field) -> decltype(field);
 template <typename T, typename Arg, typename Ret>
 auto deserializable_member(Ret (T::*setter)(Arg)) -> decltype(setter);
 
+#if __cplusplus >= 201703L
+
+template <typename T, typename Arg, typename Ret>
+auto deserializable_member(Ret (T::*setter)(Arg) noexcept) -> decltype(setter);
+
+#endif
+
 /**
  * Deserialize the given members of a custom type `T`.
  *
@@ -106,6 +113,18 @@ private:
     mserialize::deserialize(arg, istream);
     (t.*setter)(std::move(arg));
   }
+
+#if __cplusplus >= 201703L
+
+  template <typename Ret, typename Arg, typename InputStream>
+  static void deserialize_member(T& t, Ret (T::*setter)(Arg) noexcept, InputStream& istream)
+  {
+    detail::remove_cvref_t<Arg> arg;
+    mserialize::deserialize(arg, istream);
+    (t.*setter)(std::move(arg));
+  }
+
+#endif
 };
 
 } // namespace mserialize

--- a/include/mserialize/StructSerializer.hpp
+++ b/include/mserialize/StructSerializer.hpp
@@ -42,6 +42,13 @@ auto serializable_member(Field T::*field) -> decltype(field);
 template <typename T, typename Ret>
 auto serializable_member(Ret (T::*getter)() const) -> decltype(getter);
 
+#if __cplusplus >= 201703L
+
+template <typename T, typename Ret>
+auto serializable_member(Ret (T::*getter)() const noexcept) -> decltype(getter);
+
+#endif
+
 /**
  * Serialize the given members of a custom type `T`.
  *
@@ -112,6 +119,16 @@ private:
     mserialize::serialize((t.*getter)(), ostream);
   }
 
+#if __cplusplus >= 201703L
+
+  template <typename Field, typename OutputStream>
+  static void serialize_member(const T& t, Field (T::*getter)() const noexcept, OutputStream& ostream)
+  {
+    mserialize::serialize((t.*getter)(), ostream);
+  }
+
+#endif
+
   template <typename Field>
   static std::size_t serialized_size_member(const T& t, Field T::*field)
   {
@@ -123,6 +140,16 @@ private:
   {
     return mserialize::serialized_size((t.*getter)());
   }
+
+#if __cplusplus >= 201703L
+
+  template <typename Field>
+  static std::size_t serialized_size_member(const T& t, Field (T::*getter)() const noexcept)
+  {
+    return mserialize::serialized_size((t.*getter)());
+  }
+
+#endif
 };
 
 } // namespace mserialize

--- a/test/integration/IntegrationTest.cpp
+++ b/test/integration/IntegrationTest.cpp
@@ -129,6 +129,7 @@ BOOST_AUTO_TEST_CASE(Categories)            { runReadDiff("Categories", "%C %n %
 #if __cplusplus >= 201703L
 
 BOOST_AUTO_TEST_CASE(LoggingOptionals)      { runReadDiff("LoggingOptionals", "%m"); }
+BOOST_AUTO_TEST_CASE(LoggingFilesystem)     { runReadDiff("LoggingFilesystem", "%m"); }
 
 #endif
 

--- a/test/integration/LoggingFilesystem.cpp
+++ b/test/integration/LoggingFilesystem.cpp
@@ -1,0 +1,54 @@
+//[fs
+#include <binlog/adapt_stdfilesystem.hpp> // must be included to log std::filesystem types, requires C++17
+//]
+
+#include <binlog/binlog.hpp>
+
+#include <filesystem>
+#include <iostream>
+#include <system_error>
+
+int main()
+{
+  // path
+
+  //[fs
+
+  const std::filesystem::path p("/path/to/file");
+  BINLOG_INFO("std::filesystem::path: {}", p);
+  // Outputs: std::filesystem::path: /path/to/file
+  //]
+
+  // directory_entry
+  std::error_code ec;
+  const std::filesystem::directory_entry de(".", ec);
+  BINLOG_INFO("std::filesystem::directory_entry: {}", de);
+  // Outputs: std::filesystem::directory_entry: .
+
+  // directory_iterator, recursive_directory_iterator are input iterators - not supported
+
+  // file_type
+  const std::filesystem::file_type ft = std::filesystem::file_type::regular;
+  BINLOG_INFO("std::filesystem::file_type: {}", ft);
+  // Outputs: std::filesystem::file_type: regular
+
+  // perms
+  const std::filesystem::perms ps = std::filesystem::perms::owner_exec;
+  BINLOG_INFO("std::filesystem::perms: {}", ps);
+  // Outputs: std::filesystem::perms: owner_exec
+
+  // space_info
+  const std::filesystem::space_info si{3,1,1};
+  BINLOG_INFO("{}", si);
+  // Outputs: std::filesystem::space_info{ capacity: 3, free: 1, available: 1 }
+
+  // file_status
+  const std::filesystem::file_status fs{
+    std::filesystem::file_type::directory,
+    std::filesystem::perms::owner_read
+  };
+  BINLOG_INFO("{}", fs);
+  // Outputs: std::filesystem::file_status{ type: directory, permissions: owner_read }
+
+  binlog::consume(std::cout);
+}

--- a/test/unit/mserialize/roundtrip.cpp
+++ b/test/unit/mserialize/roundtrip.cpp
@@ -564,8 +564,8 @@ struct Vehicle
   std::string _name;
   std::unique_ptr<Person> _owner;
 
-  int age() const { return _age; }
-  int age(const int i) { return _age = i; }
+  int age() const noexcept { return _age; }
+  int age(const int i) noexcept { return _age = i; }
 
   std::string name() const { return _name; }
   void name(const std::string& n) { _name = n; }


### PR DESCRIPTION
- Disable some clang-tidy-9 checks
- Allow noexcept getters and setters in C++17
- Support logging of std::filesystem components

Fixes #51
