### PR TITLE
Document the limitation of using BINLOG_<SEVERITY> macros in global destructors

### DIFF
--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -339,6 +339,8 @@ metadata in the old file), old metadata has to be added via `Session::reconsumeM
 
     [catchfile example/LogRotation.cpp rotate]
 
+[Log rotation]: https://en.wikipedia.org/wiki/Log_rotation
+
 # Text Output
 
 The key feature of Binlog is producing structured, binary logfiles.
@@ -363,5 +365,19 @@ Usage is like before:
 
     [catchfile example/MultiOutput.cpp usage]
 
+# Limitations
 
-[Log rotation]: https://en.wikipedia.org/wiki/Log_rotation
+The `BINLOG_<SEVERITY>` and `BINLOG_<SEVERITY>_C` macros that do not take a writer argument
+access global state: a function local static writer and a session. Depending on the initialization order,
+in a [global destructor context][cppref-Initialization], that state might be no longer valid,
+yielding to undefined behavior. Possible resolutions include:
+
+ - Do not log in the destructor of a global object
+ - If logging in the destructor of a global object cannot be avoided,
+   make sure that initialization of the global log state is sequenced before
+   the initialization of the affected global objects
+ - Use log macros that do not access global state, e.g: `BINLOG_<SEVERITY>_W`,
+   and make sure the initialization of its writer argument is sequenced before
+   the initialization of the affected global objects
+
+[cppref-Initialization]: https://en.cppreference.com/w/cpp/language/initialization

--- a/include/binlog/basic_log_macros.hpp
+++ b/include/binlog/basic_log_macros.hpp
@@ -24,6 +24,10 @@
  * Disabled severity levels do not produce any events,
  * and do not evaluate their log arguments.
  *
+ * Global state is accessed internally (the default session and default thread local writer),
+ * avoid using these macros in a global destructor context.
+ * For greater control, see advanced_log_macros.hpp.
+ *
  * @param format string literal with {} placeholders
  * @param args... any number of serializable, tagged, log arguments. Can be empty
  */
@@ -49,6 +53,10 @@
  * Severity levels can be enabled/disabled the same way
  * as for BINLOG_<SEVERITY>. Disabled severity levels
  * do not produce any events, and do not evaluate their log arguments.
+ *
+ * Global state is accessed internally (the default session and default thread local writer),
+ * avoid using these macros in a global destructor context.
+ * For greater control, see advanced_log_macros.hpp.
  *
  * @param category arbitrary valid symbol name
  * @param format string literal with {} placeholders

--- a/include/binlog/default_session.hpp
+++ b/include/binlog/default_session.hpp
@@ -32,6 +32,10 @@ inline std::string this_thread_id_string()
  * This session is also used by basic
  * log macros, which hide the Session
  * concept from users.
+ *
+ * The implementation uses a function local static,
+ * avoid using the returned reference in the context
+ * of global destructors.
  */
 inline Session& default_session()
 {
@@ -43,6 +47,10 @@ inline Session& default_session()
  * Get a thread-local writer for default_session().
  *
  * This writer is used by basic log macros.
+ *
+ * The implementation uses a function local static,
+ * avoid using the returned reference in the context
+ * of global destructors.
  */
 inline SessionWriter& default_thread_local_writer()
 {


### PR DESCRIPTION
Fixes #91
