### PR TITLE
Allow logging pointer addresses, display them in hex

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,12 +13,14 @@ Checks: "\
   -bugprone-sizeof-expression,\
   -cppcoreguidelines-avoid-c-arrays,\
   -cppcoreguidelines-avoid-magic-numbers,\
+  -cppcoreguidelines-avoid-non-const-global-variables,\
   -cppcoreguidelines-macro-usage,\
   -cppcoreguidelines-pro-type-vararg,\
   -cppcoreguidelines-pro-type-reinterpret-cast,\
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,\
   -cppcoreguidelines-pro-bounds-constant-array-index,\
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,\
+  -cppcoreguidelines-init-variables,\
   -hicpp-*,\
   -cert-err58-cpp,\
   -cert-err60-cpp,\
@@ -27,6 +29,7 @@ Checks: "\
   -readability-named-parameter,\
   -readability-uppercase-literal-suffix,\
   -misc-non-private-member-variables-in-classes,\
+  -misc-no-recursion,\
   -modernize-avoid-c-arrays,\
   -modernize-use-auto,\
   -modernize-use-nodiscard,\
@@ -34,6 +37,7 @@ Checks: "\
   -modernize-unary-static-assert,\
   -modernize-use-trailing-return-type,\
   -llvm-header-guard,\
+  -llvmlibc-*,\
   -google-runtime-references"
 
 HeaderFilterRegex: '.*binlog/.*|.*mserialize/.*'

--- a/doc/Mserialize.md
+++ b/doc/Mserialize.md
@@ -317,18 +317,6 @@ Library design tends to be arguable. Some decisions need to be explained.
       { istream.read(buf, size) } -> InpStr&;
     };
 
-## ViewStream
-
-    template <typename VStr>
-    concept ViewStream = requires(VStr vstream, std::size_t size)
-    {
-      // Consume `size` bytes from the stream and return a pointer
-      // to the start of the consumed bytes. The returned pointer
-      // is valid until the next operation.
-      // Throw std::exception on failure (i.e: not enough bytes available)
-      { vstream.view(size) } -> const char*;
-    };
-
 ## Visitor
 
     [catchfile include/mserialize/Visitor.hpp concept]

--- a/doc/Mserialize.md
+++ b/doc/Mserialize.md
@@ -331,47 +331,7 @@ Library design tends to be arguable. Some decisions need to be explained.
 
 ## Visitor
 
-    template <typename V>
-    concept Visitor = requires(V visitor)
-    {
-      visitor.visit(bool          );
-      visitor.visit(char          );
-      visitor.visit(std::int8_t   );
-      visitor.visit(std::int16_t  );
-      visitor.visit(std::int32_t  );
-      visitor.visit(std::int64_t  );
-      visitor.visit(std::uint8_t  );
-      visitor.visit(std::uint16_t );
-      visitor.visit(std::uint32_t );
-      visitor.visit(std::uint64_t );
-
-      visitor.visit(float         );
-      visitor.visit(double        );
-      visitor.visit(long double   );
-
-      visitor.visit(mserialize::Visitor::SequenceBegin );
-      visitor.visit(mserialize::Visitor::SequenceEnd   );
-
-      visitor.visit(mserialize::Visitor::String        );
-
-      visitor.visit(mserialize::Visitor::TupleBegin    );
-      visitor.visit(mserialize::Visitor::TupleEnd      );
-
-      visitor.visit(mserialize::Visitor::VariantBegin  );
-      visitor.visit(mserialize::Visitor::VariantEnd    );
-      visitor.visit(mserialize::Visitor::Null          );
-
-      visitor.visit(mserialize::Visitor::StructBegin   );
-      visitor.visit(mserialize::Visitor::StructEnd     );
-
-      visitor.visit(mserialize::Visitor::FieldBegin    );
-      visitor.visit(mserialize::Visitor::FieldEnd      );
-
-      visitor.visit(mserialize::Visitor::Enum          );
-
-      visitor.visit(mserialize::Visitor::RepeatBegin   );
-      visitor.visit(mserialize::Visitor::RepeatEnd     );
-    };
+    [catchfile include/mserialize/Visitor.hpp concept]
 
 # References
 

--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -97,6 +97,11 @@ If the pointer is _empty_ (i.e: it points to no valid object),
 no value is logged, and in the text log it will be shown as `{null}`.
 Logging of `weak_ptr` is not supported, those must be `.lock()`-ed first.
 
+To log the address pointed by the pointer (instead of the object it points to),
+apply `binlog::address` or cast the pointer to a `void*`:
+
+    [catchfile test/integration/LoggingPointers.cpp address]
+
 If C++17 is available, the standard optional with a loggable `value_type`
 can be made loggable:
 

--- a/include/binlog/Address.hpp
+++ b/include/binlog/Address.hpp
@@ -1,0 +1,71 @@
+#ifndef BINLOG_ADDRESS_HPP
+#define BINLOG_ADDRESS_HPP
+
+#include <binlog/adapt_struct.hpp>
+
+#include <cstdint> // uintptr_t
+#include <cstring> // memcpy
+
+namespace binlog {
+
+/**
+ * Logging a pointer wrapped by this type causes bread
+ * to show the address of the pointer in hex.
+ *
+ * Otherwise the pointed value would be shown.
+ * When this object is logged, only the pointer
+ * address is serialized, the pointed value is not.
+ */
+struct address
+{
+  explicit address(const void* pointer)
+  {
+    memcpy(&value, &pointer, sizeof(value));
+  }
+
+  // To make the binary representation platform agnostic,
+  // we store the address in a u64, therefore a 64bit
+  // bread can read a log produced by a 32bit program
+  // without much complication.
+  static_assert(sizeof(void*) <= sizeof(std::uint64_t), "");
+
+  std::uint64_t value = 0;
+};
+
+} // namespace binlog
+
+BINLOG_ADAPT_STRUCT(binlog::address, value)
+
+// Log void* as address, without extra decoration
+
+namespace mserialize {
+
+template <>
+struct CustomSerializer<void*>
+{
+  template <typename OutputStream>
+  static void serialize(const void* pointer, OutputStream& ostream)
+  {
+    std::uint64_t value;
+    memcpy(&value, &pointer, sizeof(value));
+    mserialize::serialize(value, ostream);
+  }
+
+  static std::size_t serialized_size(const void*)
+  {
+    return sizeof(std::uint64_t);
+  }
+};
+
+template <>
+struct CustomSerializer<const void*> : CustomSerializer<void*> {};
+
+template <>
+struct CustomTag<void*> : CustomTag<binlog::address> {};
+
+template <>
+struct CustomTag<const void*> : CustomTag<binlog::address> {};
+
+} // namespace mserialize
+
+#endif // BINLOG_ADDRESS_HPP

--- a/include/binlog/Range.hpp
+++ b/include/binlog/Range.hpp
@@ -18,7 +18,6 @@ namespace binlog {
  * Provides convenience read() members to copy
  * data from the viewed buffer.
  * Models the mserialize::InputStream concept.
- * Models the mserialize::ViewStream concept.
  */
 class Range
 {

--- a/include/binlog/ToStringVisitor.cpp
+++ b/include/binlog/ToStringVisitor.cpp
@@ -47,12 +47,6 @@ void ToStringVisitor::visit(mserialize::Visitor::SequenceEnd)
   leaveSeq();
 }
 
-void ToStringVisitor::visit(mserialize::Visitor::String str)
-{
-  comma();
-  _out << str.data;
-}
-
 bool ToStringVisitor::visit(mserialize::Visitor::TupleBegin, const Range&)
 {
   comma();

--- a/include/binlog/ToStringVisitor.cpp
+++ b/include/binlog/ToStringVisitor.cpp
@@ -25,12 +25,14 @@ void ToStringVisitor::visit(std::uint8_t v)
   _out << unsigned(v);
 }
 
-void ToStringVisitor::visit(mserialize::Visitor::SequenceBegin)
+bool ToStringVisitor::visit(mserialize::Visitor::SequenceBegin, const Range&)
 {
   comma();
 
   _out.put('[');
   enterSeq();
+
+  return false;
 }
 
 void ToStringVisitor::visit(mserialize::Visitor::SequenceEnd)
@@ -45,11 +47,12 @@ void ToStringVisitor::visit(mserialize::Visitor::String str)
   _out << str.data;
 }
 
-void ToStringVisitor::visit(mserialize::Visitor::TupleBegin)
+bool ToStringVisitor::visit(mserialize::Visitor::TupleBegin, const Range&)
 {
   comma();
   _out.put('(');
   enterSeq();
+  return false;
 }
 
 void ToStringVisitor::visit(mserialize::Visitor::TupleEnd)
@@ -77,7 +80,7 @@ void ToStringVisitor::visit(mserialize::Visitor::Enum e)
   }
 }
 
-void ToStringVisitor::visit(mserialize::Visitor::StructBegin sb)
+bool ToStringVisitor::visit(mserialize::Visitor::StructBegin sb, const Range&)
 {
   comma();
   _out << mserialize::detail::remove_prefix_before(sb.name, '<');
@@ -90,6 +93,8 @@ void ToStringVisitor::visit(mserialize::Visitor::StructBegin sb)
     _out << "{ ";
     enterSeq();
   }
+
+  return false;
 }
 
 void ToStringVisitor::visit(mserialize::Visitor::StructEnd)

--- a/include/binlog/ToStringVisitor.cpp
+++ b/include/binlog/ToStringVisitor.cpp
@@ -25,9 +25,15 @@ void ToStringVisitor::visit(std::uint8_t v)
   _out << unsigned(v);
 }
 
-bool ToStringVisitor::visit(mserialize::Visitor::SequenceBegin, const Range&)
+bool ToStringVisitor::visit(mserialize::Visitor::SequenceBegin sb, Range& input)
 {
   comma();
+
+  if (sb.tag.size() == 1 && sb.tag[0] == 'c') // skip char-by-char visitation of strings
+  {
+    _out.write(input.view(sb.size), sb.size);
+    return true;
+  }
 
   _out.put('[');
   enterSeq();

--- a/include/binlog/ToStringVisitor.hpp
+++ b/include/binlog/ToStringVisitor.hpp
@@ -51,7 +51,7 @@ public:
 
   void visit(mserialize::Visitor::Enum);
 
-  bool visit(mserialize::Visitor::StructBegin, const Range&);
+  bool visit(mserialize::Visitor::StructBegin, Range&);
   void visit(mserialize::Visitor::StructEnd);
 
   void visit(mserialize::Visitor::FieldBegin);

--- a/include/binlog/ToStringVisitor.hpp
+++ b/include/binlog/ToStringVisitor.hpp
@@ -1,6 +1,7 @@
 #ifndef BINLOG_TO_STRING_VISITOR_HPP
 #define BINLOG_TO_STRING_VISITOR_HPP
 
+#include <binlog/Range.hpp>
 #include <binlog/detail/OstreamBuffer.hpp>
 
 #include <mserialize/Visitor.hpp>
@@ -38,21 +39,21 @@ public:
   void visit(std::int8_t);
   void visit(std::uint8_t);
 
-  void visit(mserialize::Visitor::SequenceBegin);
+  bool visit(mserialize::Visitor::SequenceBegin, const Range&);
   void visit(mserialize::Visitor::SequenceEnd);
 
   void visit(mserialize::Visitor::String);
 
-  void visit(mserialize::Visitor::TupleBegin);
+  bool visit(mserialize::Visitor::TupleBegin, const Range&);
   void visit(mserialize::Visitor::TupleEnd);
 
-  void visit(mserialize::Visitor::VariantBegin) {}
+  bool visit(mserialize::Visitor::VariantBegin, const Range&) { return false; }
   void visit(mserialize::Visitor::VariantEnd) {}
   void visit(mserialize::Visitor::Null);
 
   void visit(mserialize::Visitor::Enum);
 
-  void visit(mserialize::Visitor::StructBegin);
+  bool visit(mserialize::Visitor::StructBegin, const Range&);
   void visit(mserialize::Visitor::StructEnd);
 
   void visit(mserialize::Visitor::FieldBegin);

--- a/include/binlog/ToStringVisitor.hpp
+++ b/include/binlog/ToStringVisitor.hpp
@@ -39,7 +39,7 @@ public:
   void visit(std::int8_t);
   void visit(std::uint8_t);
 
-  bool visit(mserialize::Visitor::SequenceBegin, const Range&);
+  bool visit(mserialize::Visitor::SequenceBegin, Range&);
   void visit(mserialize::Visitor::SequenceEnd);
 
   void visit(mserialize::Visitor::String);

--- a/include/binlog/ToStringVisitor.hpp
+++ b/include/binlog/ToStringVisitor.hpp
@@ -42,8 +42,6 @@ public:
   bool visit(mserialize::Visitor::SequenceBegin, Range&);
   void visit(mserialize::Visitor::SequenceEnd);
 
-  void visit(mserialize::Visitor::String);
-
   bool visit(mserialize::Visitor::TupleBegin, const Range&);
   void visit(mserialize::Visitor::TupleEnd);
 

--- a/include/binlog/binlog.hpp
+++ b/include/binlog/binlog.hpp
@@ -6,6 +6,7 @@
  * which includes commonly used headers.
  */
 
+#include <binlog/Address.hpp>
 #include <binlog/ArrayView.hpp>
 #include <binlog/adapt_enum.hpp>
 #include <binlog/adapt_struct.hpp>

--- a/include/mserialize/Visitor.hpp
+++ b/include/mserialize/Visitor.hpp
@@ -16,6 +16,12 @@ namespace mserialize {
  * During visitation, the `visit` methods
  * are called, according to the given
  * type tag and input stream.
+ *
+ * Some `visit` methods take an InputStream argument:
+ * The visitor can decide to consume the complete
+ * object indicated by the type tag from the given InputStream,
+ * and `return true` to signal that visitation of
+ * this object must be skipped.
 //[concept
 template <typename V, typename InputStream>
 concept Visitor = requires(V visitor)
@@ -35,19 +41,19 @@ concept Visitor = requires(V visitor)
   visitor.visit(double        );
   visitor.visit(long double   );
 
-  visitor.visit(mserialize::Visitor::SequenceBegin );
+  visitor.visit(mserialize::Visitor::SequenceBegin, InputStream&) -> bool;
   visitor.visit(mserialize::Visitor::SequenceEnd   );
 
   visitor.visit(mserialize::Visitor::String        );
 
-  visitor.visit(mserialize::Visitor::TupleBegin    )
+  visitor.visit(mserialize::Visitor::TupleBegin, InputStream&) -> bool;
   visitor.visit(mserialize::Visitor::TupleEnd      );
 
-  visitor.visit(mserialize::Visitor::VariantBegin  );
+  visitor.visit(mserialize::Visitor::VariantBegin, InputStream&) -> bool;
   visitor.visit(mserialize::Visitor::VariantEnd    );
   visitor.visit(mserialize::Visitor::Null          );
 
-  visitor.visit(mserialize::Visitor::StructBegin   );
+  visitor.visit(mserialize::Visitor::StructBegin, InputStream&) -> bool;
   visitor.visit(mserialize::Visitor::StructEnd     );
 
   visitor.visit(mserialize::Visitor::FieldBegin    );

--- a/include/mserialize/Visitor.hpp
+++ b/include/mserialize/Visitor.hpp
@@ -81,13 +81,6 @@ struct Visitor
   };
   struct SequenceEnd {};
 
-  // String - a special Sequence of char, for efficiency
-
-  struct String
-  {
-    string_view data;
-  };
-
   // Tuple
 
   struct TupleBegin

--- a/include/mserialize/Visitor.hpp
+++ b/include/mserialize/Visitor.hpp
@@ -7,21 +7,65 @@
 
 namespace mserialize {
 
-/**
- * Interface/concept of the `visitor` argument of mserialize::visit.
+/*
+ * Concept of the `visitor` argument of mserialize::visit.
  *
  * The Visitor object given to mserialize::visit
- * must derive from this class OR must have methods
- * matching the virtual methods of this class.
+ * must model this concept.
  *
  * During visitation, the `visit` methods
- * will be called, according to the given
+ * are called, according to the given
  * type tag and input stream.
+//[concept
+template <typename V, typename InputStream>
+concept Visitor = requires(V visitor)
+{
+  visitor.visit(bool          );
+  visitor.visit(char          );
+  visitor.visit(std::int8_t   );
+  visitor.visit(std::int16_t  );
+  visitor.visit(std::int32_t  );
+  visitor.visit(std::int64_t  );
+  visitor.visit(std::uint8_t  );
+  visitor.visit(std::uint16_t );
+  visitor.visit(std::uint32_t );
+  visitor.visit(std::uint64_t );
+
+  visitor.visit(float         );
+  visitor.visit(double        );
+  visitor.visit(long double   );
+
+  visitor.visit(mserialize::Visitor::SequenceBegin );
+  visitor.visit(mserialize::Visitor::SequenceEnd   );
+
+  visitor.visit(mserialize::Visitor::String        );
+
+  visitor.visit(mserialize::Visitor::TupleBegin    )
+  visitor.visit(mserialize::Visitor::TupleEnd      );
+
+  visitor.visit(mserialize::Visitor::VariantBegin  );
+  visitor.visit(mserialize::Visitor::VariantEnd    );
+  visitor.visit(mserialize::Visitor::Null          );
+
+  visitor.visit(mserialize::Visitor::StructBegin   );
+  visitor.visit(mserialize::Visitor::StructEnd     );
+
+  visitor.visit(mserialize::Visitor::FieldBegin    );
+  visitor.visit(mserialize::Visitor::FieldEnd      );
+
+  visitor.visit(mserialize::Visitor::Enum          );
+
+  visitor.visit(mserialize::Visitor::RepeatBegin   );
+  visitor.visit(mserialize::Visitor::RepeatEnd     );
+};
+//]
+*/
+
+/**
+ * Collection of the visit tags `mserialize::visit` use.
  */
 struct Visitor
 {
-  virtual ~Visitor() = default;
-
   // Sequence
 
   struct SequenceBegin
@@ -97,44 +141,6 @@ struct Visitor
     std::uint32_t size{}; /**< Number of time the previous visted value repeats */
     string_view tag;      /**< Type tag of the repeating value */
   };
-
-  // visitor methods - to be implemented by derived type
-
-  virtual void visit(bool          ) = 0;
-  virtual void visit(char          ) = 0;
-  virtual void visit(std::int8_t   ) = 0;
-  virtual void visit(std::int16_t  ) = 0;
-  virtual void visit(std::int32_t  ) = 0;
-  virtual void visit(std::int64_t  ) = 0;
-  virtual void visit(std::uint8_t  ) = 0;
-  virtual void visit(std::uint16_t ) = 0;
-  virtual void visit(std::uint32_t ) = 0;
-  virtual void visit(std::uint64_t ) = 0;
-
-  virtual void visit(float         ) = 0;
-  virtual void visit(double        ) = 0;
-  virtual void visit(long double   ) = 0;
-
-  virtual void visit(SequenceBegin ) = 0;
-  virtual void visit(SequenceEnd   ) = 0;
-
-  virtual void visit(TupleBegin    ) = 0;
-  virtual void visit(TupleEnd      ) = 0;
-
-  virtual void visit(VariantBegin  ) = 0;
-  virtual void visit(VariantEnd    ) = 0;
-  virtual void visit(Null          ) = 0;
-
-  virtual void visit(StructBegin   ) = 0;
-  virtual void visit(StructEnd     ) = 0;
-
-  virtual void visit(FieldBegin    ) = 0;
-  virtual void visit(FieldEnd      ) = 0;
-
-  virtual void visit(Enum          ) = 0;
-
-  virtual void visit(RepeatBegin   ) = 0;
-  virtual void visit(RepeatEnd     ) = 0;
 };
 
 } // namespace mserialize

--- a/include/mserialize/detail/Serializer.hpp
+++ b/include/mserialize/detail/Serializer.hpp
@@ -6,6 +6,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <ios> // streamsize (macOS)
 #include <type_traits>
 
 namespace mserialize {

--- a/include/mserialize/detail/Visit.hpp
+++ b/include/mserialize/detail/Visit.hpp
@@ -78,7 +78,8 @@ void visit_arithmetic(char tag, Visitor& visitor, InputStream& istream)
 template <typename Visitor, typename InputStream>
 void visit_sequence_impl(const string_view full_tag, const string_view elem_tag, std::uint32_t size, Visitor& visitor, InputStream& istream, int max_recursion, char)
 {
-  visitor.visit(mserialize::Visitor::SequenceBegin{size, elem_tag});
+  const bool skip = visitor.visit(mserialize::Visitor::SequenceBegin{size, elem_tag}, istream);
+  if (skip) { return; }
 
   if (size > 32 && singular(full_tag, elem_tag, max_recursion))
   {
@@ -134,7 +135,8 @@ void visit_tuple(const string_view full_tag, string_view tag, Visitor& visitor, 
   tag.remove_prefix(1); // drop (
   tag.remove_suffix(1); // drop )
 
-  visitor.visit(mserialize::Visitor::TupleBegin{tag});
+  const bool skip = visitor.visit(mserialize::Visitor::TupleBegin{tag}, istream);
+  if (skip) { return; }
 
   for (string_view elem_tag = tag_pop(tag); ! elem_tag.empty(); elem_tag = tag_pop(tag))
   {
@@ -159,7 +161,8 @@ void visit_variant(const string_view full_tag, string_view tag, Visitor& visitor
 
   const string_view option_tag = tag_pop(tag);
 
-  visitor.visit(mserialize::Visitor::VariantBegin{discriminator, option_tag});
+  const bool skip = visitor.visit(mserialize::Visitor::VariantBegin{discriminator, option_tag}, istream);
+  if (skip) { return; }
 
   if (option_tag == "0")
   {
@@ -199,7 +202,8 @@ void visit_struct(const string_view full_tag, string_view tag, Visitor& visitor,
 
   intro.remove_prefix(1); // drop {
 
-  visitor.visit(mserialize::Visitor::StructBegin{intro, tag});
+  const bool skip = visitor.visit(mserialize::Visitor::StructBegin{intro, tag}, istream);
+  if (skip) { return; }
 
   while (! tag.empty())
   {

--- a/include/mserialize/visit.hpp
+++ b/include/mserialize/visit.hpp
@@ -13,8 +13,6 @@ namespace mserialize {
  *
  * @requires `visitor` to model the Visitor concept, see Vistor.hpp
  * @requires `istream` must model the mserialize::InputStream concept.
- *   If `istream` also models the mserialize::ViewStream concept,
- *   visitation of strings is more efficient.
  * @pre `tag` must be a valid type tag, e.g:
  *   a tag returned by mserialize::tag<T>().
  * @pre `istream` must contain a serialized object,

--- a/include/mserialize/visit.hpp
+++ b/include/mserialize/visit.hpp
@@ -11,9 +11,7 @@ namespace mserialize {
 /**
  * Visit the serialized objects in `istream`.
  *
- * @requires `visitor` to model the Visitor concept,
- *   which is implicitly given by the virtual
- *   members of the `mserialize::Vistor` type.
+ * @requires `visitor` to model the Visitor concept, see Vistor.hpp
  * @requires `istream` must model the mserialize::InputStream concept.
  *   If `istream` also models the mserialize::ViewStream concept,
  *   visitation of strings is more efficient.

--- a/test/integration/LoggingPointers.cpp
+++ b/test/integration/LoggingPointers.cpp
@@ -5,7 +5,6 @@
 #include <boost/smart_ptr/weak_ptr.hpp>
 
 #include <iostream>
-
 #include <memory>
 
 int main()
@@ -32,6 +31,28 @@ int main()
     !mserialize::detail::is_serializable<std::weak_ptr<int>>::value,
     "std::weak_ptr is not loggable"
   );
+
+  // Addresses (raw pointer value)
+
+  std::uintptr_t address = 0xf777123;
+
+  int* any_pointer = nullptr;
+  void* void_pointer = nullptr;
+  std::memcpy(&any_pointer, &address, sizeof(any_pointer));
+  std::memcpy(&void_pointer, &address, sizeof(void_pointer));
+
+  //[address
+  BINLOG_INFO("Raw pointer value: {} {}", binlog::address(any_pointer), void_pointer);
+  // Outputs: Raw pointer value: 0xF777123 0xF777123
+  //]
+
+  const int* const_any_pointer = nullptr;
+  const void* const_void_pointer = nullptr;
+  std::memcpy(&const_any_pointer, &address, sizeof(const_any_pointer));
+  std::memcpy(&const_void_pointer, &address, sizeof(const_void_pointer));
+
+  BINLOG_INFO("Const pointer value: {} {}", binlog::address(const_any_pointer), const_void_pointer);
+  // Outputs: Const pointer value: 0xF777123 0xF777123
 
   // Boost pointers - no specific adoption is required
 

--- a/test/unit/binlog/TestPrettyPrinter.cpp
+++ b/test/unit/binlog/TestPrettyPrinter.cpp
@@ -35,7 +35,7 @@ struct TestcaseBase
   binlog::WriterProp writerProp{789, "writer", 0};
   binlog::ClockSync clockSync{0, 1, 0, 5400, "XYZ"};
 
-  std::string print(binlog::PrettyPrinter& pp)
+  std::string print(binlog::PrettyPrinter& pp) const
   {
     std::ostringstream str;
     pp.printEvent(str, event, writerProp, clockSync);

--- a/test/unit/binlog/TestToStringVisitor.cpp
+++ b/test/unit/binlog/TestToStringVisitor.cpp
@@ -82,13 +82,9 @@ BOOST_FIXTURE_TEST_CASE(sequence_of_int, TestcaseBase)
 
 BOOST_FIXTURE_TEST_CASE(sequence_of_char, TestcaseBase)
 {
-  visitor.visit(V::SequenceBegin{3, "c"}, input);
-  visitor.visit('a');
-  visitor.visit('b');
-  visitor.visit('c');
-  visitor.visit(V::SequenceEnd{});
-
-  BOOST_TEST(result() == "[a, b, c]");
+  input = binlog::Range("abc", 3);
+  BOOST_TEST(visitor.visit(V::SequenceBegin{3, "c"}, input));
+  BOOST_TEST(result() == "abc");
 }
 
 
@@ -120,22 +116,14 @@ BOOST_FIXTURE_TEST_CASE(seq_of_seq_of_int, TestcaseBase)
 
 BOOST_FIXTURE_TEST_CASE(seq_of_seq_of_char, TestcaseBase)
 {
+  input = binlog::Range("abcdef", 6);
   visitor.visit(V::SequenceBegin{3, "[c"}, input);
-  visitor.visit(V::SequenceBegin{2, "c"}, input);
-  visitor.visit('a');
-  visitor.visit('b');
-  visitor.visit(V::SequenceEnd{});
-  visitor.visit(V::SequenceBegin{2, "c"}, input);
-  visitor.visit('c');
-  visitor.visit('d');
-  visitor.visit(V::SequenceEnd{});
-  visitor.visit(V::SequenceBegin{2, "c"}, input);
-  visitor.visit('e');
-  visitor.visit('f');
-  visitor.visit(V::SequenceEnd{});
+  BOOST_TEST(visitor.visit(V::SequenceBegin{2, "c"}, input));
+  BOOST_TEST(visitor.visit(V::SequenceBegin{2, "c"}, input));
+  BOOST_TEST(visitor.visit(V::SequenceBegin{2, "c"}, input));
   visitor.visit(V::SequenceEnd{});
 
-  BOOST_TEST(result() == "[[a, b], [c, d], [e, f]]");
+  BOOST_TEST(result() == "[ab, cd, ef]");
 }
 
 BOOST_FIXTURE_TEST_CASE(empty_tuple, TestcaseBase)

--- a/test/unit/binlog/TestToStringVisitor.cpp
+++ b/test/unit/binlog/TestToStringVisitor.cpp
@@ -87,13 +87,6 @@ BOOST_FIXTURE_TEST_CASE(sequence_of_char, TestcaseBase)
   BOOST_TEST(result() == "abc");
 }
 
-
-BOOST_FIXTURE_TEST_CASE(string, TestcaseBase)
-{
-  visitor.visit(V::String{{"abc"}});
-  BOOST_TEST(result() == "abc");
-}
-
 BOOST_FIXTURE_TEST_CASE(seq_of_seq_of_int, TestcaseBase)
 {
   visitor.visit(V::SequenceBegin{3, "[i"}, input);

--- a/test/unit/binlog/TestToStringVisitor.cpp
+++ b/test/unit/binlog/TestToStringVisitor.cpp
@@ -22,6 +22,7 @@ struct TestcaseBase
 {
   using V = mserialize::Visitor;
 
+  binlog::Range input;
   std::ostringstream str;
   binlog::detail::OstreamBuffer buf{str};
   binlog::ToStringVisitor visitor{buf};
@@ -63,14 +64,14 @@ BOOST_FIXTURE_TEST_CASE_TEMPLATE(arithmetic, T, not_bool_arithmetic_types, Testc
 
 BOOST_FIXTURE_TEST_CASE(empty_sequence_of_int, TestcaseBase)
 {
-  visitor.visit(V::SequenceBegin{0, "i"});
+  visitor.visit(V::SequenceBegin{0, "i"}, input);
   visitor.visit(V::SequenceEnd{});
   BOOST_TEST(result() == "[]");
 }
 
 BOOST_FIXTURE_TEST_CASE(sequence_of_int, TestcaseBase)
 {
-  visitor.visit(V::SequenceBegin{3, "i"});
+  visitor.visit(V::SequenceBegin{3, "i"}, input);
   visitor.visit(int(1));
   visitor.visit(int(2));
   visitor.visit(int(3));
@@ -81,7 +82,7 @@ BOOST_FIXTURE_TEST_CASE(sequence_of_int, TestcaseBase)
 
 BOOST_FIXTURE_TEST_CASE(sequence_of_char, TestcaseBase)
 {
-  visitor.visit(V::SequenceBegin{3, "c"});
+  visitor.visit(V::SequenceBegin{3, "c"}, input);
   visitor.visit('a');
   visitor.visit('b');
   visitor.visit('c');
@@ -99,16 +100,16 @@ BOOST_FIXTURE_TEST_CASE(string, TestcaseBase)
 
 BOOST_FIXTURE_TEST_CASE(seq_of_seq_of_int, TestcaseBase)
 {
-  visitor.visit(V::SequenceBegin{3, "[i"});
-  visitor.visit(V::SequenceBegin{2, "i"});
+  visitor.visit(V::SequenceBegin{3, "[i"}, input);
+  visitor.visit(V::SequenceBegin{2, "i"}, input);
   visitor.visit(int(1));
   visitor.visit(int(2));
   visitor.visit(V::SequenceEnd{});
-  visitor.visit(V::SequenceBegin{2, "i"});
+  visitor.visit(V::SequenceBegin{2, "i"}, input);
   visitor.visit(int(3));
   visitor.visit(int(4));
   visitor.visit(V::SequenceEnd{});
-  visitor.visit(V::SequenceBegin{2, "i"});
+  visitor.visit(V::SequenceBegin{2, "i"}, input);
   visitor.visit(int(5));
   visitor.visit(int(6));
   visitor.visit(V::SequenceEnd{});
@@ -119,16 +120,16 @@ BOOST_FIXTURE_TEST_CASE(seq_of_seq_of_int, TestcaseBase)
 
 BOOST_FIXTURE_TEST_CASE(seq_of_seq_of_char, TestcaseBase)
 {
-  visitor.visit(V::SequenceBegin{3, "[c"});
-  visitor.visit(V::SequenceBegin{2, "c"});
+  visitor.visit(V::SequenceBegin{3, "[c"}, input);
+  visitor.visit(V::SequenceBegin{2, "c"}, input);
   visitor.visit('a');
   visitor.visit('b');
   visitor.visit(V::SequenceEnd{});
-  visitor.visit(V::SequenceBegin{2, "c"});
+  visitor.visit(V::SequenceBegin{2, "c"}, input);
   visitor.visit('c');
   visitor.visit('d');
   visitor.visit(V::SequenceEnd{});
-  visitor.visit(V::SequenceBegin{2, "c"});
+  visitor.visit(V::SequenceBegin{2, "c"}, input);
   visitor.visit('e');
   visitor.visit('f');
   visitor.visit(V::SequenceEnd{});
@@ -139,14 +140,14 @@ BOOST_FIXTURE_TEST_CASE(seq_of_seq_of_char, TestcaseBase)
 
 BOOST_FIXTURE_TEST_CASE(empty_tuple, TestcaseBase)
 {
-  visitor.visit(V::TupleBegin{""});
+  visitor.visit(V::TupleBegin{""}, input);
   visitor.visit(V::TupleEnd{});
   BOOST_TEST(result() == "()");
 }
 
 BOOST_FIXTURE_TEST_CASE(tuple_of_int_bool_char, TestcaseBase)
 {
-  visitor.visit(V::TupleBegin{"iyc"});
+  visitor.visit(V::TupleBegin{"iyc"}, input);
   visitor.visit(int(1));
   visitor.visit(true);
   visitor.visit('a');
@@ -157,14 +158,14 @@ BOOST_FIXTURE_TEST_CASE(tuple_of_int_bool_char, TestcaseBase)
 
 BOOST_FIXTURE_TEST_CASE(seq_of_variant, TestcaseBase)
 {
-  visitor.visit(V::SequenceBegin{3, "<0i>"});
-  visitor.visit(V::VariantBegin{1, "i"});
+  visitor.visit(V::SequenceBegin{3, "<0i>"}, input);
+  visitor.visit(V::VariantBegin{1, "i"}, input);
   visitor.visit(V::Null{});
   visitor.visit(V::VariantEnd{});
-  visitor.visit(V::VariantBegin{0, "0"});
+  visitor.visit(V::VariantBegin{0, "0"}, input);
   visitor.visit(int(1));
   visitor.visit(V::VariantEnd{});
-  visitor.visit(V::VariantBegin{1, "i"});
+  visitor.visit(V::VariantBegin{1, "i"}, input);
   visitor.visit(int(2));
   visitor.visit(V::VariantEnd{});
   visitor.visit(V::SequenceEnd{});
@@ -174,7 +175,7 @@ BOOST_FIXTURE_TEST_CASE(seq_of_variant, TestcaseBase)
 
 BOOST_FIXTURE_TEST_CASE(seq_of_enum, TestcaseBase)
 {
-  visitor.visit(V::SequenceBegin{3, "/i`E'0`a'1`b'\\"});
+  visitor.visit(V::SequenceBegin{3, "/i`E'0`a'1`b'\\"}, input);
   visitor.visit(V::Enum{"E", "b", 'i', "1"});
   visitor.visit(V::Enum{"E", "a", 'i', "2"});
   visitor.visit(V::Enum{"E", "", 'i', "3"});
@@ -185,21 +186,21 @@ BOOST_FIXTURE_TEST_CASE(seq_of_enum, TestcaseBase)
 
 BOOST_FIXTURE_TEST_CASE(empty_struct, TestcaseBase)
 {
-  visitor.visit(V::StructBegin{"Empty", ""});
+  visitor.visit(V::StructBegin{"Empty", ""}, input);
   visitor.visit(V::StructEnd{});
   BOOST_TEST(result() == "Empty");
 }
 
 BOOST_FIXTURE_TEST_CASE(empty_struct_template, TestcaseBase)
 {
-  visitor.visit(V::StructBegin{"Empty<A,B,C>", ""});
+  visitor.visit(V::StructBegin{"Empty<A,B,C>", ""}, input);
   visitor.visit(V::StructEnd{});
   BOOST_TEST(result() == "Empty");
 }
 
 BOOST_FIXTURE_TEST_CASE(simple_struct, TestcaseBase)
 {
-  visitor.visit(V::StructBegin{"Alpha", "`a'i`b'y"});
+  visitor.visit(V::StructBegin{"Alpha", "`a'i`b'y"}, input);
   visitor.visit(V::FieldBegin{"a", "i"});
   visitor.visit(int(1));
   visitor.visit(V::FieldEnd{});
@@ -213,15 +214,15 @@ BOOST_FIXTURE_TEST_CASE(simple_struct, TestcaseBase)
 
 BOOST_FIXTURE_TEST_CASE(pair_of_structs, TestcaseBase)
 {
-  visitor.visit(V::TupleBegin{"{Alpha`a'i}{Empty}{Beta`b'y}"});
-  visitor.visit(V::StructBegin{"Alpha", "`a'i"});
+  visitor.visit(V::TupleBegin{"{Alpha`a'i}{Empty}{Beta`b'y}"}, input);
+  visitor.visit(V::StructBegin{"Alpha", "`a'i"}, input);
   visitor.visit(V::FieldBegin{"a", "i"});
   visitor.visit(int(1));
   visitor.visit(V::FieldEnd{});
   visitor.visit(V::StructEnd{});
-  visitor.visit(V::StructBegin{"Empty", ""});
+  visitor.visit(V::StructBegin{"Empty", ""}, input);
   visitor.visit(V::StructEnd{});
-  visitor.visit(V::StructBegin{"Beta", "`b'y"});
+  visitor.visit(V::StructBegin{"Beta", "`b'y"}, input);
   visitor.visit(V::FieldBegin{"b", "y"});
   visitor.visit(true);
   visitor.visit(V::FieldEnd{});
@@ -233,16 +234,16 @@ BOOST_FIXTURE_TEST_CASE(pair_of_structs, TestcaseBase)
 
 BOOST_FIXTURE_TEST_CASE(struct_of_structs, TestcaseBase)
 {
-  visitor.visit(V::StructBegin{"Alpha", "`ccc'{Beta`d'i}`e'{Empty}"});
+  visitor.visit(V::StructBegin{"Alpha", "`ccc'{Beta`d'i}`e'{Empty}"}, input);
   visitor.visit(V::FieldBegin{"ccc", "{Beta`d'i}"});
-  visitor.visit(V::StructBegin{"Beta", "`d'i"});
+  visitor.visit(V::StructBegin{"Beta", "`d'i"}, input);
   visitor.visit(V::FieldBegin{"d", "i"});
   visitor.visit(int(1));
   visitor.visit(V::FieldEnd{});
   visitor.visit(V::StructEnd{});
   visitor.visit(V::FieldEnd{});
   visitor.visit(V::FieldBegin{"e", "{Empty}"});
-  visitor.visit(V::StructBegin{"Empty", ""});
+  visitor.visit(V::StructBegin{"Empty", ""}, input);
   visitor.visit(V::StructEnd{});
   visitor.visit(V::FieldEnd{});
   visitor.visit(V::StructEnd{});
@@ -252,7 +253,7 @@ BOOST_FIXTURE_TEST_CASE(struct_of_structs, TestcaseBase)
 
 BOOST_FIXTURE_TEST_CASE(empty_field_name, TestcaseBase)
 {
-  visitor.visit(V::StructBegin{"BoundedInt", "`'i"});
+  visitor.visit(V::StructBegin{"BoundedInt", "`'i"}, input);
   visitor.visit(V::FieldBegin{"", "i"});
   visitor.visit(int(1024));
   visitor.visit(V::FieldEnd{});

--- a/test/unit/mserialize/documentation.cpp
+++ b/test/unit/mserialize/documentation.cpp
@@ -141,6 +141,7 @@ struct CustomTag<Node>
 struct Visitor
 {
   template <typename T> void visit(T) {}
+  template <typename T> bool visit(T, std::ifstream&) { return false; }
 };
 
 BOOST_AUTO_TEST_SUITE(Documentation)

--- a/test/unit/mserialize/test_streams.hpp
+++ b/test/unit/mserialize/test_streams.hpp
@@ -3,7 +3,6 @@
 
 #include <ios> // streamsize
 #include <sstream>
-#include <vector>
 
 // In tests, do not use std streams directly,
 // to make sure tested code only accesses
@@ -28,27 +27,6 @@ struct InputStream
   {
     stream.read(buf, size);
     return *this;
-  }
-};
-
-struct ViewStream
-{
-  std::stringstream& stream;
-  std::vector<char> buf;
-
-  explicit ViewStream(std::stringstream& s) :stream(s) {}
-
-  ViewStream& read(char* buffer, std::streamsize size)
-  {
-    stream.read(buffer, size);
-    return *this;
-  }
-
-  const char* view(std::size_t size)
-  {
-    buf.resize(size);
-    stream.read(buf.data(), std::streamsize(size));
-    return buf.data();
   }
 };
 

--- a/test/unit/mserialize/visit.cpp
+++ b/test/unit/mserialize/visit.cpp
@@ -66,8 +66,6 @@ public:
   bool visit(mserialize::Visitor::SequenceBegin sb, IS&) { _str << "SB(" << sb.size << ',' << sb.tag << ")[ "; return false; }
   void visit(mserialize::Visitor::SequenceEnd)      { _str << "] "; }
 
-  void visit(mserialize::Visitor::String str)       { _str << "Str(" << str.data << ") "; }
-
   template <typename IS>
   bool visit(mserialize::Visitor::TupleBegin tb, IS&)    { _str << "TB(" << tb.tag << ")( "; return false; }
   void visit(mserialize::Visitor::TupleEnd)         { _str << ") "; }
@@ -109,7 +107,7 @@ public:
   int value() const { return _count; }
 };
 
-template <typename Visitor, typename T, typename IS = InputStream>
+template <typename Visitor, typename T>
 typename Visitor::value_type
 serialize_and_visit(const T& in)
 {
@@ -122,7 +120,7 @@ serialize_and_visit(const T& in)
 
   // visit
   Visitor visitor;
-  IS istream{stream};
+  InputStream istream{stream};
   const auto tag = mserialize::tag<T>();
   mserialize::visit(tag, visitor, istream);
 
@@ -222,20 +220,6 @@ BOOST_AUTO_TEST_CASE(vector_of_char)
   const std::vector<char> in{'f','o','o','b','a','r'};
   const std::string out = serialize_and_visit<ToString>(in);
   BOOST_TEST(out == "SB(6,c)[ f o o b a r ] ");
-}
-
-BOOST_AUTO_TEST_CASE(vector_of_char_view_stream)
-{
-  const std::vector<char> in{'f','o','o','b','a','r'};
-  const std::string out = serialize_and_visit<ToString, std::vector<char>, ViewStream>(in);
-  BOOST_TEST(out == "Str(foobar) ");
-}
-
-BOOST_AUTO_TEST_CASE(string)
-{
-  const std::string in = "barbaz";
-  const std::string out = serialize_and_visit<ToString, std::string, ViewStream>(in);
-  BOOST_TEST(out == "Str(barbaz) ");
 }
 
 BOOST_AUTO_TEST_CASE(empty_tuple)

--- a/test/unit/mserialize/visit.cpp
+++ b/test/unit/mserialize/visit.cpp
@@ -35,6 +35,9 @@ public:
   template <typename U>
   void visit(const U&) { BOOST_FAIL("Unexpected visit of U"); }
 
+  template <typename U>
+  bool visit(const U&, InputStream&) { BOOST_FAIL("Unexpected visit of U"); return false; }
+
   T value()
   {
     BOOST_TEST(_has_visit);
@@ -59,15 +62,18 @@ public:
   void visit(std::int8_t v)    { _str << int(v) << ' '; }
   void visit(std::uint8_t v)   { _str << unsigned(v) << ' '; }
 
-  void visit(mserialize::Visitor::SequenceBegin sb) { _str << "SB(" << sb.size << ',' << sb.tag << ")[ "; }
+  template <typename IS>
+  bool visit(mserialize::Visitor::SequenceBegin sb, IS&) { _str << "SB(" << sb.size << ',' << sb.tag << ")[ "; return false; }
   void visit(mserialize::Visitor::SequenceEnd)      { _str << "] "; }
 
   void visit(mserialize::Visitor::String str)       { _str << "Str(" << str.data << ") "; }
 
-  void visit(mserialize::Visitor::TupleBegin tb)    { _str << "TB(" << tb.tag << ")( "; }
+  template <typename IS>
+  bool visit(mserialize::Visitor::TupleBegin tb, IS&)    { _str << "TB(" << tb.tag << ")( "; return false; }
   void visit(mserialize::Visitor::TupleEnd)         { _str << ") "; }
 
-  void visit(mserialize::Visitor::VariantBegin vb)  { _str << "VB(" << vb.discriminator << ',' << vb.tag << ")< "; }
+  template <typename IS>
+  bool visit(mserialize::Visitor::VariantBegin vb, IS&)  { _str << "VB(" << vb.discriminator << ',' << vb.tag << ")< "; return false; }
   void visit(mserialize::Visitor::VariantEnd)       { _str << "> "; }
   void visit(mserialize::Visitor::Null)             { _str << "{null} "; }
 
@@ -76,7 +82,8 @@ public:
     _str << "E(" << e.name << "::" << e.enumerator << ',' << e.tag << ",0x" << e.value << ") ";
   }
 
-  void visit(mserialize::Visitor::StructBegin sb)   { _str << "StB(" << sb.name << ',' << sb.tag << ") { "; }
+  template <typename IS>
+  bool visit(mserialize::Visitor::StructBegin sb, IS&)   { _str << "StB(" << sb.name << ',' << sb.tag << ") { "; return false; }
   void visit(mserialize::Visitor::StructEnd)        { _str << "} "; }
 
   void visit(mserialize::Visitor::FieldBegin fb)    { _str << fb.name << '(' << fb.tag << "): "; }
@@ -95,6 +102,9 @@ class CountingVisitor
 public:
   template <typename T>
   void visit(T) { ++_count; }
+
+  template <typename T>
+  bool visit(T, std::stringstream&) { ++_count; return false; }
 
   int value() const { return _count; }
 };


### PR DESCRIPTION
Motivation:

    BINLOG_INFO("Raw pointer value: {} {}", binlog::address(any_pointer), void_pointer);
    // Outputs: Raw pointer value: 0xF777123 0xF777123

- Move the definition of the Visitor concept into a comment
- Allow skipping visitation of composit objects
- ToStringVisitor: skip char-by-char visitation of char sequences
- Revert "Visit sequence of chars in one batch instead of byte-by-byte"
  It is no longer needed
- Allow logging pointer addresses, display them in hex

The C++20 specified remove_cvref does not remove the `const` from
a `const void*`, therefore we need one CustomSerializer and
CustomTag for both `void*` and `const void*`.

Logging addresses as uintptr_t was considered,
the advantage being saved space on x32.
However, that requires the ToStringVisitor to do a bit more work
(ensure that the field tag is valid, fetch a tag specific
integral depending on the field type) - and the extra complexity was too high.

Fixes #41 .
