### PR TITLE
Replaced alternative operators "and not" with "&& !"

### DIFF
--- a/include/mserialize/cx_string.hpp
+++ b/include/mserialize/cx_string.hpp
@@ -33,7 +33,7 @@ public:
   explicit constexpr cx_string(const char* str)
     :_data{0}
   {
-    #if defined(__GNUC__) and not defined(__clang__)
+    #if defined(__GNUC__) && !defined(__clang__)
       // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96742
       #pragma GCC diagnostic push
       #pragma GCC diagnostic ignored "-Wtype-limits"
@@ -42,7 +42,7 @@ public:
     {
       _data[i] = str[i];
     }
-    #if defined(__GNUC__) and not defined(__clang__)
+    #if defined(__GNUC__) && !defined(__clang__)
       #pragma GCC diagnostic pop
     #endif
   }

--- a/include/mserialize/detail/integer_to_hex.hpp
+++ b/include/mserialize/detail/integer_to_hex.hpp
@@ -19,13 +19,13 @@ constexpr std::size_t hex_string_size(Integer v)
   }
   else
   {
-    #if defined(__GNUC__) and not defined(__clang__)
+    #if defined(__GNUC__) && !defined(__clang__)
       // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96742
       #pragma GCC diagnostic push
       #pragma GCC diagnostic ignored "-Wtype-limits"
     #endif
     for (; std::int64_t(v) < 0; v /= 16) { ++size; }
-    #if defined(__GNUC__) and not defined(__clang__)
+    #if defined(__GNUC__) && !defined(__clang__)
       #pragma GCC diagnostic pop
     #endif
   }


### PR DESCRIPTION
This was done for consistency purposes and for eliminating issues with some compilers that would otherwise require including `<ciso646>` (which was removed in C++20).