### PR TITLE
Make BINLOG_ADAPT_ENUM work with shadowed enum types

### DIFF
--- a/include/mserialize/make_enum_tag.hpp
+++ b/include/mserialize/make_enum_tag.hpp
@@ -35,9 +35,9 @@
 #define MSERIALIZE_MAKE_ENUM_TAG(...)                          \
   namespace mserialize {                                       \
   template <>                                                  \
-  struct CustomTag<MSERIALIZE_FIRST(__VA_ARGS__)>              \
+  struct CustomTag<enum MSERIALIZE_FIRST(__VA_ARGS__)>         \
   {                                                            \
-    using Enum = MSERIALIZE_FIRST(__VA_ARGS__);                \
+    typedef enum MSERIALIZE_FIRST(__VA_ARGS__) Enum;           \
     using underlying_t = std::underlying_type_t<Enum>;         \
                                                                \
     static constexpr auto tag_string()                         \

--- a/test/unit/mserialize/tag.cpp
+++ b/test/unit/mserialize/tag.cpp
@@ -109,6 +109,9 @@ static_assert(mserialize::tag<test::LargeEnumClass>() == "/l`test::LargeEnumClas
 MSERIALIZE_MAKE_ENUM_TAG(test::UnsignedLargeEnumClass, Lima, Mike, November, Oscar)
 static_assert(mserialize::tag<test::UnsignedLargeEnumClass>() == "/L`test::UnsignedLargeEnumClass'0`Lima'400`Mike'4000`November'FFFFFFFFFFFFFFFF`Oscar'\\", "");
 
+MSERIALIZE_MAKE_ENUM_TAG(test::EnumNest::Nested, Bird)
+static_assert(mserialize::tag<enum test::EnumNest::Nested>() == "/i`test::EnumNest::Nested'0`Bird'\\", "");
+
 // test MSERIALIZE_MAKE_STRUCT_TAG
 
 struct Empty {};

--- a/test/unit/mserialize/test_enums.hpp
+++ b/test/unit/mserialize/test_enums.hpp
@@ -36,6 +36,14 @@ enum class UnsignedLargeEnumClass : std::uint64_t
   Oscar = UINT64_MAX
 };
 
+struct EnumNest
+{
+  enum class Nested
+  {
+    Bird
+  } Nested; // field name and enum name are the same
+};
+
 } // namespace test
 
 #endif // TEST_UNIT_MSERIALIZE_TEST_ENUMS_HPP


### PR DESCRIPTION
using X = enum Y; doesn't work, typedef enum Y X does.
Fixes #124 