### PR TITLE
Make BINLOG_ADAPT_ENUM work with unnamed typedefed enums

### DIFF
--- a/include/mserialize/detail/type_traits.hpp
+++ b/include/mserialize/detail/type_traits.hpp
@@ -107,6 +107,11 @@ struct deep_remove_const<const T<E...>> : deep_remove_const<T<E...>> {};
 template <typename T>
 using deep_remove_const_t = typename deep_remove_const<T>::type;
 
+// type_identity (c++20)
+
+template <typename T>
+struct type_identity { using type = T; };
+
 } // namespace detail
 } // namespace mserialize
 

--- a/include/mserialize/make_enum_tag.hpp
+++ b/include/mserialize/make_enum_tag.hpp
@@ -5,6 +5,7 @@
 #include <mserialize/detail/foreach.hpp>
 #include <mserialize/detail/integer_to_hex.hpp>
 #include <mserialize/detail/preprocessor.hpp>
+#include <mserialize/detail/type_traits.hpp>
 #include <mserialize/tag.hpp>
 
 /**
@@ -35,9 +36,11 @@
 #define MSERIALIZE_MAKE_ENUM_TAG(...)                          \
   namespace mserialize {                                       \
   template <>                                                  \
-  struct CustomTag<enum MSERIALIZE_FIRST(__VA_ARGS__)>         \
+  struct CustomTag<typename ::MSERIALIZE_FIRST(__VA_ARGS__)>   \
   {                                                            \
-    typedef enum MSERIALIZE_FIRST(__VA_ARGS__) Enum;           \
+    using Enum = detail::type_identity<                        \
+      typename ::MSERIALIZE_FIRST(__VA_ARGS__)                 \
+    >::type;                                                   \
     using underlying_t = std::underlying_type_t<Enum>;         \
                                                                \
     static constexpr auto tag_string()                         \

--- a/test/unit/mserialize/tag.cpp
+++ b/test/unit/mserialize/tag.cpp
@@ -112,6 +112,12 @@ static_assert(mserialize::tag<test::UnsignedLargeEnumClass>() == "/L`test::Unsig
 MSERIALIZE_MAKE_ENUM_TAG(test::EnumNest::Nested, Bird)
 static_assert(mserialize::tag<enum test::EnumNest::Nested>() == "/i`test::EnumNest::Nested'0`Bird'\\", "");
 
+MSERIALIZE_MAKE_ENUM_TAG(test::UnnamedEnumTypedef, Papa)
+static_assert(mserialize::tag<test::UnnamedEnumTypedef>() == "/i`test::UnnamedEnumTypedef'0`Papa'\\", "");
+
+MSERIALIZE_MAKE_ENUM_TAG(UnscopedEnum, Quebec)
+static_assert(mserialize::tag<UnscopedEnum>() == "/i`UnscopedEnum'0`Quebec'\\", "");
+
 // test MSERIALIZE_MAKE_STRUCT_TAG
 
 struct Empty {};

--- a/test/unit/mserialize/test_enums.hpp
+++ b/test/unit/mserialize/test_enums.hpp
@@ -44,6 +44,14 @@ struct EnumNest
   } Nested; // field name and enum name are the same
 };
 
+typedef enum : int {
+  Papa
+} UnnamedEnumTypedef;
+
 } // namespace test
+
+enum UnscopedEnum : int {
+  Quebec
+};
 
 #endif // TEST_UNIT_MSERIALIZE_TEST_ENUMS_HPP

--- a/test/unit/mserialize/visit.cpp
+++ b/test/unit/mserialize/visit.cpp
@@ -13,6 +13,7 @@
 #include <doctest/doctest.h>
 
 #include <sstream>
+#include <limits>
 
 namespace {
 


### PR DESCRIPTION
Broken by the previous commit. Fixes #124 again.