### PR TITLE
Add NOLINTs to BINLOG_CREATE_SOURCE_AND_EVENT

### DIFF
--- a/include/binlog/create_source_and_event.hpp
+++ b/include/binlog/create_source_and_event.hpp
@@ -47,8 +47,8 @@
     if (_binlog_sid_v == 0)                                                                  \
     {                                                                                        \
       _binlog_sid_v = writer.session().addEventSource(binlog::EventSource{                   \
-        0, severity, #category, __func__, __FILE__, __LINE__, MSERIALIZE_FIRST(__VA_ARGS__), \
-        binlog::detail::concatenated_tags(__VA_ARGS__).data()                                \
+        0, severity, #category, __func__, __FILE__, __LINE__, MSERIALIZE_FIRST(__VA_ARGS__), /* NOLINT */ \
+        binlog::detail::concatenated_tags(__VA_ARGS__).data()                                /* NOLINT */ \
       });                                                                                    \
       _binlog_sid.store(_binlog_sid_v);                                                      \
     }                                                                                        \


### PR DESCRIPTION
To silence cppcoreguidelines-pro-bounds-array-to-pointer-decay.
(I consider the suggested code inferior, as it hurts readability)
The nolints are bad enough, but the macro expands in user code,
where our .clang-tidy config does not take effect.

Repro:

    clang-tidy --extra-arg=-Iinclude/ example/HelloWorld.cpp --checks=cppcoreguidelines-pro-bounds-array-to-pointer-decay

Fixes #43
