### PR TITLE
Document limitation of adopting shadowed enum types

### DIFF
--- a/doc/UserGuide.md
+++ b/doc/UserGuide.md
@@ -152,6 +152,11 @@ For scoped enums, the enumerators must be prefixed with the enum name, as usual:
 
 The maximum number of enumerators is limited to 100.
 
+To adapt enum types shadowed by non-type declarations (e.g: a field),
+the following workaround is required:
+
+    [catchfile test/integration/LoggingEnums.cpp shadowed]
+
 ## Logging User Defined Structures
 
 User defined types outside the categories above can be still logged,

--- a/include/mserialize/make_enum_tag.hpp
+++ b/include/mserialize/make_enum_tag.hpp
@@ -35,9 +35,9 @@
 #define MSERIALIZE_MAKE_ENUM_TAG(...)                          \
   namespace mserialize {                                       \
   template <>                                                  \
-  struct CustomTag<enum MSERIALIZE_FIRST(__VA_ARGS__)>         \
+  struct CustomTag<MSERIALIZE_FIRST(__VA_ARGS__)>              \
   {                                                            \
-    typedef enum MSERIALIZE_FIRST(__VA_ARGS__) Enum;           \
+    using Enum = MSERIALIZE_FIRST(__VA_ARGS__);                \
     using underlying_t = std::underlying_type_t<Enum>;         \
                                                                \
     static constexpr auto tag_string()                         \

--- a/test/integration/LoggingEnums.cpp
+++ b/test/integration/LoggingEnums.cpp
@@ -19,6 +19,19 @@ BINLOG_ADAPT_ENUM(ScopedEnum, Epsilon, Phi)
 enum PartiallyAdaptedEnum { Rho = 20, Sigma = 30, Tau = 40 };
 BINLOG_ADAPT_ENUM(PartiallyAdaptedEnum, Rho, Sigma)
 
+//[shadowed
+struct Nest {
+  enum Nested
+  {
+    Bird
+  } Nested; // Note: field name is same as enum name
+};
+
+// BINLOG_ADAPT_ENUM(Nest::Nested, Bird) // Doesn't work, type is shadowed by field.
+typedef enum Nest::Nested NestedT; // workaround: use elaborated type specifier
+BINLOG_ADAPT_ENUM(NestedT, Bird)
+//]
+
 int main()
 {
   //[basic
@@ -41,6 +54,9 @@ int main()
 
   BINLOG_INFO("Partially adapted enum: {} {} {}", Rho, Sigma, Tau);
   // Outputs: Partially adapted enum: Rho Sigma 0x28
+
+  BINLOG_INFO("Shadowed enum type: {}", Nest::Nested::Bird);
+  // Outputs: Shadowed enum type: Bird
 
   binlog::consume(std::cout);
   return 0;

--- a/test/unit/mserialize/tag.cpp
+++ b/test/unit/mserialize/tag.cpp
@@ -109,6 +109,12 @@ static_assert(mserialize::tag<test::LargeEnumClass>() == "/l`test::LargeEnumClas
 MSERIALIZE_MAKE_ENUM_TAG(test::UnsignedLargeEnumClass, Lima, Mike, November, Oscar)
 static_assert(mserialize::tag<test::UnsignedLargeEnumClass>() == "/L`test::UnsignedLargeEnumClass'0`Lima'400`Mike'4000`November'FFFFFFFFFFFFFFFF`Oscar'\\", "");
 
+MSERIALIZE_MAKE_ENUM_TAG(test::UnnamedEnumTypedef, Papa)
+static_assert(mserialize::tag<test::UnnamedEnumTypedef>() == "/i`test::UnnamedEnumTypedef'0`Papa'\\", "");
+
+MSERIALIZE_MAKE_ENUM_TAG(UnscopedEnum, Quebec)
+static_assert(mserialize::tag<UnscopedEnum>() == "/i`UnscopedEnum'0`Quebec'\\", "");
+
 // test MSERIALIZE_MAKE_STRUCT_TAG
 
 struct Empty {};

--- a/test/unit/mserialize/tag.cpp
+++ b/test/unit/mserialize/tag.cpp
@@ -109,9 +109,6 @@ static_assert(mserialize::tag<test::LargeEnumClass>() == "/l`test::LargeEnumClas
 MSERIALIZE_MAKE_ENUM_TAG(test::UnsignedLargeEnumClass, Lima, Mike, November, Oscar)
 static_assert(mserialize::tag<test::UnsignedLargeEnumClass>() == "/L`test::UnsignedLargeEnumClass'0`Lima'400`Mike'4000`November'FFFFFFFFFFFFFFFF`Oscar'\\", "");
 
-MSERIALIZE_MAKE_ENUM_TAG(test::EnumNest::Nested, Bird)
-static_assert(mserialize::tag<enum test::EnumNest::Nested>() == "/i`test::EnumNest::Nested'0`Bird'\\", "");
-
 // test MSERIALIZE_MAKE_STRUCT_TAG
 
 struct Empty {};

--- a/test/unit/mserialize/test_enums.hpp
+++ b/test/unit/mserialize/test_enums.hpp
@@ -36,6 +36,15 @@ enum class UnsignedLargeEnumClass : std::uint64_t
   Oscar = UINT64_MAX
 };
 
+
+typedef enum : int {
+  Papa
+} UnnamedEnumTypedef;
+
 } // namespace test
+
+enum UnscopedEnum : int {
+  Quebec
+};
 
 #endif // TEST_UNIT_MSERIALIZE_TEST_ENUMS_HPP

--- a/test/unit/mserialize/test_enums.hpp
+++ b/test/unit/mserialize/test_enums.hpp
@@ -36,14 +36,6 @@ enum class UnsignedLargeEnumClass : std::uint64_t
   Oscar = UINT64_MAX
 };
 
-struct EnumNest
-{
-  enum class Nested
-  {
-    Bird
-  } Nested; // field name and enum name are the same
-};
-
 } // namespace test
 
 #endif // TEST_UNIT_MSERIALIZE_TEST_ENUMS_HPP

--- a/test/unit/mserialize/visit.cpp
+++ b/test/unit/mserialize/visit.cpp
@@ -12,6 +12,7 @@
 
 #include <doctest/doctest.h>
 
+#include <limits>
 #include <sstream>
 
 namespace {


### PR DESCRIPTION
- Revert "Make BINLOG_ADAPT_ENUM work with shadowed enum types"
- Add tests for UnnamedEnumTypedef and UnscopedEnum
- Add missing include
- Document and test workaround for adopting shadowed enums

Fixes #124 again.
