### PR TITLE
Improve bread performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,7 @@ add_example(TscClock)
     test/unit/binlog/TestTextOutputStream.cpp
     test/unit/binlog/TestEventFilter.cpp
     test/unit/binlog/detail/TestOstreamBuffer.cpp
+    test/unit/binlog/detail/TestSegmentedMap.cpp
 
     bin/printers.cpp
     test/unit/binlog/TestPrinters.cpp

--- a/bin/bread.cpp
+++ b/bin/bread.cpp
@@ -100,7 +100,7 @@ int main(int argc, /*const*/ char* argv[])
   bool sorted = false;
 
   int opt;
-  while ((opt = getopt(argc, argv, "f:d:sh")) != -1)
+  while ((opt = getopt(argc, argv, "f:d:sh")) != -1) // NOLINT(concurrency-mt-unsafe)
   {
     switch (opt)
     {

--- a/include/binlog/EventStream.cpp
+++ b/include/binlog/EventStream.cpp
@@ -43,7 +43,7 @@ void EventStream::readEventSource(Range range)
 {
   EventSource eventSource;
   mserialize::deserialize(eventSource, range);
-  _eventSources[eventSource.id] = std::move(eventSource);
+  _eventSources.emplace(eventSource.id, std::move(eventSource));
 }
 
 void EventStream::readWriterProp(Range range)
@@ -64,13 +64,13 @@ void EventStream::readClockSync(Range range)
 
 void EventStream::readEvent(std::uint64_t eventSourceId, Range range)
 {
-  auto it = _eventSources.find(eventSourceId);
+  auto&& it = _eventSources.find(eventSourceId);
   if (it == _eventSources.end())
   {
     throw std::runtime_error("Event has invalid source id: " + std::to_string(eventSourceId));
   }
 
-  _event.source = &it->second;
+  _event.source = it;
   _event.clockValue = range.read<std::uint64_t>();
   _event.arguments = range;
 }

--- a/include/binlog/EventStream.hpp
+++ b/include/binlog/EventStream.hpp
@@ -5,6 +5,8 @@
 #include <binlog/EntryStream.hpp>
 #include <binlog/Range.hpp>
 
+#include <binlog/detail/SegmentedMap.hpp>
+
 #include <istream>
 #include <map>
 
@@ -55,7 +57,7 @@ private:
 
   void readEvent(std::uint64_t eventSourceId, Range range);
 
-  std::map<std::uint64_t, EventSource> _eventSources; // TODO(benedek) perf: use SegmentedMap
+  detail::SegmentedMap<EventSource> _eventSources;
   WriterProp _writerProp;
   ClockSync _clockSync;
   Event _event;

--- a/include/binlog/detail/SegmentedMap.hpp
+++ b/include/binlog/detail/SegmentedMap.hpp
@@ -1,0 +1,105 @@
+#ifndef BINLOG_DETAIL_SEGMENTEDMAP_H_
+#define BINLOG_DETAIL_SEGMENTEDMAP_H_
+
+#include <cstdint>
+#include <utility> // forward
+#include <vector>
+
+namespace binlog {
+namespace detail {
+
+/**
+ * A map<size_t, V> like container,
+ * optimized for mostly numerically contiguous keys.
+ *
+ * Values of contiguous keys are stored
+ * in a vector - contiguously.
+ */
+template <typename V>
+class SegmentedMap
+{
+public:
+  using key_type = std::uint64_t;
+  using mapped_type = V;
+
+private:
+  using Segment = std::vector<mapped_type>;
+
+  // Invariant: _offsets[i] == key_of(_segments[i][0])
+  // Invariant: key_of(_segments[i][j]) + 1 == key_of(_segments[i][j + 1])
+  //
+  // _offsets is never empty, to make lookup cheaper
+
+  std::vector<key_type> _offsets{0};
+  std::vector<Segment> _segments{{}};
+
+public:
+  template <class... Args>
+  void emplace(const key_type key, Args&&... args)
+  {
+    const key_type si = segmentIndex(key);
+    const key_type offset = _offsets[si];
+    const key_type vi = key - offset;
+    Segment& segment = _segments[si];
+
+    if (segment.size() == vi)
+    {
+      segment.emplace_back(std::forward<Args>(args)...);
+    }
+    else if (segment.size() > vi)
+    {
+      segment[vi] = mapped_type(std::forward<Args>(args)...);
+    }
+    else
+    {
+      const auto ito = std::vector<key_type>::iterator::difference_type(si + 1);
+      _offsets.insert(_offsets.begin() + ito, key);
+      _segments.emplace(_segments.begin() + ito, Segment{mapped_type(std::forward<Args>(args)...)});
+    }
+  }
+
+  bool empty() const
+  {
+    return size() == 0;
+  }
+
+  std::size_t size() const
+  {
+    std::size_t s = 0;
+    for (const Segment& segment : _segments)
+    {
+      s += segment.size();
+    }
+    return s;
+  }
+
+  mapped_type* end() const { return nullptr; }
+
+  const mapped_type* find(const key_type& key) const
+  {
+    const key_type si = segmentIndex(key);
+    const key_type offset = _offsets[si];
+    const key_type vi = key - offset;
+    const Segment& segment = _segments[si];
+
+    if (vi < segment.size())
+    {
+      return & segment[vi];
+    }
+
+    return end();
+  }
+
+private:
+  key_type segmentIndex(const key_type key) const
+  {
+    key_type si = 1;
+    for (; si < _offsets.size() && _offsets[si] <= key; ++si) { /* nop */; }
+    return si - 1;
+  }
+};
+
+} // namespace detail
+} // namespace binlog
+
+#endif // BINLOG_DETAIL_SEGMENTEDMAP_H_

--- a/test/integration/LoggingEnums.cpp
+++ b/test/integration/LoggingEnums.cpp
@@ -28,7 +28,7 @@ struct Nest {
 };
 
 // BINLOG_ADAPT_ENUM(Nest::Nested, Bird) // Doesn't work, type is shadowed by field.
-typedef enum Nest::Nested NestedT; // workaround: use elaborated type specifier
+typedef enum Nest::Nested NestedT; // workaround: use elaborated type specifier // NOLINT
 BINLOG_ADAPT_ENUM(NestedT, Bird)
 //]
 

--- a/test/integration/LoggingTimePoint.cpp
+++ b/test/integration/LoggingTimePoint.cpp
@@ -14,7 +14,7 @@ int main()
   #ifdef _WIN32
     _putenv_s("TZ", "UTC");
   #else
-    setenv("TZ", "UTC", 1);
+    setenv("TZ", "UTC", 1); // NOLINT(concurrency-mt-unsafe)
   #endif
 
   //[timepoint

--- a/test/unit/binlog/TestTime.cpp
+++ b/test/unit/binlog/TestTime.cpp
@@ -45,7 +45,7 @@ TEST_CASE("system_clock_measures_utc")
 
   const std::chrono::system_clock::time_point epoch_tp{};
   const std::time_t epoch_tt = std::chrono::system_clock::to_time_t(epoch_tp);
-  const std::tm* t = std::gmtime(&epoch_tt);
+  const std::tm* t = std::gmtime(&epoch_tt); // NOLINT(concurrency-mt-unsafe)
 
   REQUIRE(t != nullptr);
   CHECK(t->tm_year == 70);

--- a/test/unit/binlog/detail/TestSegmentedMap.cpp
+++ b/test/unit/binlog/detail/TestSegmentedMap.cpp
@@ -1,0 +1,57 @@
+#include <binlog/detail/SegmentedMap.hpp>
+
+#include <doctest/doctest.h>
+
+using IntMap = binlog::detail::SegmentedMap<int>;
+
+TEST_CASE("basics")
+{
+  IntMap m;
+  CHECK(m.empty());
+  CHECK(m.size() == 0);
+  CHECK(m.find(0) == m.end());
+  CHECK(m.find(123) == m.end());
+  CHECK(m.find(IntMap::key_type(-1)) == m.end());
+}
+
+TEST_CASE("emplace")
+{
+  IntMap m;
+
+  CHECK(m.find(123) == m.end());
+
+  m.emplace(123, 1000);
+  auto&& f1 = m.find(123);
+  CHECK(f1 != m.end());
+  CHECK(*f1 == 1000);
+  CHECK(m.find(0) == m.end());
+  CHECK(m.find(122) == m.end());
+  CHECK(m.find(124) == m.end());
+  CHECK(! m.empty());
+  CHECK(m.size() == 1);
+}
+
+TEST_CASE("emplace_more")
+{
+  IntMap m;
+
+  for (int j = 0; j < 5000; j += 1000)
+  {
+    for (int i = 0; i < 100; ++i)
+    {
+      const int key = j + i;
+      m.emplace(IntMap::key_type(key), j * i);
+    }
+  }
+
+  CHECK(m.size() == 500);
+
+  for (int j = 0; j < 5000; j += 1000)
+  {
+    for (int i = 0; i < 100; ++i)
+    {
+      const int key = j + i;
+      CHECK(*m.find(IntMap::key_type(key)) == j * i);
+    }
+  }
+}

--- a/test/unit/binlog/test_utils.cpp
+++ b/test/unit/binlog/test_utils.cpp
@@ -55,7 +55,7 @@ std::string timePointToString(std::chrono::system_clock::time_point tp)
 {
   char buffer[128] = {0};
   const std::time_t tt = std::chrono::system_clock::to_time_t(tp);
-  const std::tm* tm = std::localtime(&tt);
+  const std::tm* tm = std::localtime(&tt); // NOLINT(concurrency-mt-unsafe)
   strftime(buffer, 128, "%Y.%m.%d %H:%M:%S", tm);
   return buffer;
 }


### PR DESCRIPTION
The SegmentedMap type is optimized for mostly contiguous keys.
Makes a difference for logfiles with a large number of event sources.