### PR TITLE
Make has_tag work with adapted templates

### DIFF
--- a/include/binlog/adapt_stdvariant.hpp
+++ b/include/binlog/adapt_stdvariant.hpp
@@ -55,6 +55,13 @@ struct CustomSerializer<std::variant<T...>>
 template <typename... T>
 struct CustomTag<std::variant<T...>>
 {
+  // Make this type not-constructible, if some Tag<T> is not constructible
+  std::conditional_t<
+    detail::conjunction<detail::has_tag<T>...>::value,
+    std::true_type,
+    mserialize::detail::BuiltinTag<void>
+  > tag_guard;
+
   static constexpr auto tag_string()
   {
     return cx_strcat(

--- a/test/integration/LoggingVariants.cpp
+++ b/test/integration/LoggingVariants.cpp
@@ -91,3 +91,11 @@ int main()
 
   binlog::consume(std::cout);
 }
+
+struct Adapted {};
+BINLOG_ADAPT_STRUCT(Adapted)
+
+struct NotAdapted {};
+
+static_assert(mserialize::detail::has_tag<std::variant<Adapted>>::value, "");
+static_assert(!mserialize::detail::has_tag<std::variant<NotAdapted>>::value, "");

--- a/test/unit/mserialize/tag.cpp
+++ b/test/unit/mserialize/tag.cpp
@@ -188,3 +188,23 @@ MSERIALIZE_MAKE_DERIVED_STRUCT_TAG(Derived2, (Derived1))
 static_assert(mserialize::tag<Derived2>() == "{Derived2`'{Derived1`'{Base2`'{Base1`a'i}`b'i}`'{Base3`c'[c}`d'i`e'i}}", "");
 
 #endif // _WIN32
+
+// test has_tag
+
+// This is a private method, but still useful sometimes,
+// e.g: user wants to check if a template with a random member is loggable or not.
+
+struct Adapted{};
+MSERIALIZE_MAKE_STRUCT_TAG(Adapted)
+
+struct NotAdapted{};
+
+template <typename Nested>
+struct Nest
+{
+  Nested n;
+};
+MSERIALIZE_MAKE_TEMPLATE_TAG((typename Nested), (Nest<Nested>), n)
+
+static_assert(mserialize::detail::has_tag<Nest<Adapted>>::value, "");
+static_assert(!mserialize::detail::has_tag<Nest<NotAdapted>>::value, "");


### PR DESCRIPTION
Previously has_tag reported true, even if the specified template
had members (depending on the template arguments) that did not have
a tag. Fixes #145