### PR TITLE
String may be the first string in a section

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -106,9 +106,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Dependencies
         run: |
-          # remove broken packages installed by default
-          sudo apt remove -y clang-6.0 libclang-common-6.0-dev libclang1-6.0 libllvm6.0
-          sudo apt install -y clang clang-tidy
+          sudo apt install -y clang clang-tidy ldd
       - name: Configure
         run: |
           set -x

--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -106,7 +106,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Dependencies
         run: |
-          sudo apt install -y clang clang-tidy ldd
+          sudo apt install -y clang clang-tidy lld
       - name: Configure
         run: |
           set -x

--- a/include/binlog/detail/read_sources_linux.hpp
+++ b/include/binlog/detail/read_sources_linux.hpp
@@ -42,7 +42,7 @@ inline void add_event_sources_of_file(const std::string& path, std::uintptr_t lo
   {
     for (const ElfW(Shdr)& shdr : shdrs)
     {
-      if (shdr.sh_addr < v && shdr.sh_addr + shdr.sh_size > v)
+      if (shdr.sh_addr <= v && shdr.sh_addr + shdr.sh_size > v)
       {
         return v - shdr.sh_addr + shdr.sh_offset;
       }


### PR DESCRIPTION
When searching for the correct section for a string we should consider the case where the string is the very first string in a section.

Without this change sometimes a certain severity level string will be "found" in the wrong section header causing it to be garbage which falls though to the base case in severityFromString and turns into Severity::no_logs or "off" when printing to text.