### PR TITLE
Time.hpp - use duration cast to ensure nanoseconds

### DIFF
--- a/include/binlog/Time.hpp
+++ b/include/binlog/Time.hpp
@@ -106,7 +106,7 @@ inline ClockSync systemClockSync()
   #endif
 
   return ClockSync{
-    std::uint64_t(since_epoch.count()),
+    std::uint64_t(std::chrono::duration_cast<std::chrono::nanoseconds>(since_epoch).count()),
     frequency,
     std::uint64_t(std::chrono::duration_cast<std::chrono::nanoseconds>(since_epoch).count()),
     offset,


### PR DESCRIPTION
https://github.com/morganstanley/binlog/issues/171