### PR TITLE
Increase float precision when printing

### DIFF
--- a/include/binlog/detail/OstreamBuffer.cpp
+++ b/include/binlog/detail/OstreamBuffer.cpp
@@ -47,14 +47,14 @@ OstreamBuffer& OstreamBuffer::operator<<(bool b)
 OstreamBuffer& OstreamBuffer::operator<<(double v)
 {
   reserve(64);
-  _p += snprintf(_p, 64, "%g", v);
+  _p += snprintf(_p, 64, "%.16g", v);
   return *this;
 }
 
 OstreamBuffer& OstreamBuffer::operator<<(long double v)
 {
   reserve(128);
-  _p += snprintf(_p, 128, "%Lg", v);
+  _p += snprintf(_p, 128, "%.16Lg", v);
   return *this;
 }
 

--- a/test/integration/LoggingFundamentals.cpp
+++ b/test/integration/LoggingFundamentals.cpp
@@ -21,6 +21,13 @@ void logUnsigned()
   BINLOG_INFO("{} {} {} {}", a, b, c, T(40));
 }
 
+template <typename T>
+void logDouble()
+{
+  T f = 1234234.0234242;
+  BINLOG_INFO("{}", f);
+}
+
 int main()
 {
   logSigned<signed short>(); // NOLINT
@@ -65,6 +72,11 @@ int main()
   // Outputs: -20 30 30 -40
   // Outputs: -20 30 30 -40
   // Outputs: -20 30 30 -40
+
+  logDouble<double>();
+  logDouble<long double>();
+  // Outputs: 1234234.0234242
+  // Outputs: 1234234.0234242
 
   char c = 'A';
   const char cc = 'B';

--- a/test/unit/binlog/detail/TestOstreamBuffer.cpp
+++ b/test/unit/binlog/detail/TestOstreamBuffer.cpp
@@ -70,18 +70,16 @@ TEST_CASE_FIXTURE(TestcaseBase, "shift_op")
 
   CHECK(toString<float>(0.0f) == "0");
   CHECK(toString<float>(1.0f) == "1");
-  CHECK(toString<float>(1.2f) == "1.2");
-  CHECK(toString<float>(123.456f) == "123.456");
+  CHECK(toString<float>(120.5625f) == "120.5625");
 
   CHECK(toString<double>(0.0) == "0");
   CHECK(toString<double>(1.0) == "1");
-  CHECK(toString<double>(-1.2) == "-1.2");
-  CHECK(toString<double>(123.456) == "123.456");
+  CHECK(toString<double>(120.5625) == "120.5625");
 
   CHECK(toString<long double>(0.0) == "0");
   CHECK(toString<long double>(1.0) == "1");
-  CHECK(toString<long double>(1.2) == "1.2");
-  CHECK(toString<long double>(-123.456) == "-123.456");
+  CHECK(toString<long double>(-120.5625) == "-120.5625");
+  CHECK(toString<long double>(1234234.0234242) == "1234234.0234242");
 
   CHECK(toString("foobar") == "foobar");
 }


### PR DESCRIPTION
To avoid scientific notation.
Fixes #175
